### PR TITLE
Fix crash for projects without a remote on haxelib

### DIFF
--- a/src/haxe/ui/haxelib/HaxeLibManager.hx
+++ b/src/haxe/ui/haxelib/HaxeLibManager.hx
@@ -48,7 +48,13 @@ class HaxeLibManager extends tools.haxelib.Main {
 	}
 	
 	public function queryProject(projectName:String):ProjectInfos {
-		return site.infos(projectName);
+		var infos:ProjectInfos = null;
+		try  {
+			infos = site.infos(projectName);
+		} catch (e:Dynamic) {
+			// project might not be on haxelib, e.g. if installed via haxelib git
+		}
+		return infos;
 	}
 	
 	public function listLocalProjects(filter:String = null, loadRemote:Bool = false):Array<Dynamic> {

--- a/src/haxe/ui/haxelib/RemoteFetchRunner.hx
+++ b/src/haxe/ui/haxelib/RemoteFetchRunner.hx
@@ -36,18 +36,10 @@ class RemoteFetchRunner extends Runner {
 	}
 	
 	public override function run() {
-		if (_progressBar.visible == false) {
-			_progressBar.visible = true;
-		}
-		if (_progressSpacer.visible == true) {
-			_progressSpacer.visible = false;
-		}
-		if (_progressButton.disabled == false) {
-			_progressButton.disabled = true;
-		}
-		if (_lv.disabled == false) {
-			_lv.disabled = true;
-		}
+		_progressBar.visible = true;
+		_progressSpacer.visible = false;
+		_progressButton.disabled = true;
+		_lv.disabled = true;
 		
 		_lv.dataSource.moveFirst();
 		for (x in 0..._breakIndex) {
@@ -68,22 +60,29 @@ class RemoteFetchRunner extends Runner {
 			var projectName:String = data.project.name;
 			var currentVersion:String = data.project.currentVersion;
 			var remoteProject:ProjectInfos = HaxeLibManager.instance.queryProject(projectName);
-			data.project.remoteProject = remoteProject;
-			var currentVersion:String = data.project.currentVersion;
-			if (currentVersion != remoteProject.curversion) {
-				data.componentValue = remoteProject.curversion + " Available";
-				data.icon = "img/blue-folder-horizontal-exclamation-disabled.png";
-				_outOfDateProjects++;
+			
+			if (remoteProject != null) {
+				data.project.remoteProject = remoteProject;
+				var currentVersion:String = data.project.currentVersion;
+				if (currentVersion != remoteProject.curversion) {
+					data.componentValue = remoteProject.curversion + " Available";
+					data.icon = "img/blue-folder-horizontal-exclamation-disabled.png";
+					_outOfDateProjects++;
+				} else {
+					data.icon = "img/blue-folder-horizontal-tick-disabled.png";
+				}
+				/*
+				trace(projectName + ":");
+				trace("localVersions = " + data.project.localVersions);
+				trace("remoteVersions = " + remoteInfo.versions);
+				trace("");
+				*/
+				data.subtext = remoteProject.desc;
 			} else {
-				data.icon = "img/blue-folder-horizontal-tick-disabled.png";
+				data.icon = "img/blue-folder-horizontal.png";
+				data.subtext = "";
 			}
-			/*
-			trace(projectName + ":");
-			trace("localVersions = " + data.project.localVersions);
-			trace("remoteVersions = " + remoteInfo.versions);
-			trace("");
-			*/
-			data.subtext = remoteProject.desc;
+			
 			n++;
 			x++;
 		} while (_lv.dataSource.moveNext()); 
@@ -94,7 +93,7 @@ class RemoteFetchRunner extends Runner {
 			var data:Dynamic = _lv.dataSource.get();
 			if (data.icon == "img/blue-folder-horizontal-exclamation-disabled.png") {
 				data.icon = "img/blue-folder-horizontal-exclamation.png";
-			} else {
+			} else if (data.icon != "img/blue-folder-horizontal.png") {
 				data.icon = "img/blue-folder-horizontal-tick.png";
 			}
 		} while (_lv.dataSource.moveNext()); 

--- a/src/haxe/ui/haxelib/popups/ManageLocalProjectController.hx
+++ b/src/haxe/ui/haxelib/popups/ManageLocalProjectController.hx
@@ -12,15 +12,16 @@ class ManageLocalProjectController extends XMLController {
 	public function new(project:Dynamic) {
 		_project = project;
 		
-		refreshDetails();
-		refreshVersions();
+		if (_project.remoteProject != null) {
+			refreshDetails();
+			refreshVersions();
+			queryUser.onClick = function(e) {
+				UIManager.instance.showQueryUser(_project.remoteProject.owner);
+			};
+		}
 		
 		close.onClick = function(e) {
 			cast(view.parent.parent, Popup).clickButton(PopupButton.CLOSE);
-		};
-		
-		queryUser.onClick = function(e) {
-			UIManager.instance.showQueryUser(_project.remoteProject.owner);
 		};
 		
 		projectVersions.onComponentEvent = function(e:UIEvent) {


### PR DESCRIPTION
Previously, the assumption was that there's a remote on lib.haxe.org for every project installed in haxelib, which does not have to be the case (for example when a project was installed via `haxelib git`). This led to a crash.

There are no infos available for projects without a remote (making the manage project popup useless) - in the future, the local `haxelib.json` file should be parsed for such projects. This pull at least prevents the crashing.
