### PR TITLE
Add a filter textbox

### DIFF
--- a/application.xml
+++ b/application.xml
@@ -10,7 +10,7 @@
 	
 	<window background="#FFFFFF" fps="60" />
 	<window width="800" height="600" unless="mobile" />
-	<window orientation="landscape" vsync="false" antialiasing="0" if="cpp" />
+	<window orientation="landscape" if="cpp" />
 	
 	<!-- classpath, haxe libs -->
 	<source path="src" />
@@ -20,7 +20,7 @@
 	
 	<!-- assets -->
 	<icon path="assets/haxe.svg" />
-	<assets path="assets" rename="assets" />
+	<assets path="assets" />
 	<assets path="assets/img" rename="img" />
 	<assets path="assets/ui" rename="ui" />
 	

--- a/assets/ui/main.xml
+++ b/assets/ui/main.xml
@@ -52,6 +52,8 @@
 		<text id="title" text="Haxelib Client" />
 	</menubar>
 	
+	<textinput id="filter" placeholderText="Filter by name" horizontalAlign="right" />
+	
 	<tabview width="100%" height="100%" id="mainTabs">
 		<vbox text="Local Repository" width="100%" height="100%">
 			<listview id="localProjects" width="100%" height="100%" itemRenderer="haxe.ui.toolkit.core.renderers.ComponentItemRenderer"/>

--- a/src/haxe/ui/haxelib/HaxeLibManager.hx
+++ b/src/haxe/ui/haxelib/HaxeLibManager.hx
@@ -244,11 +244,9 @@ class HaxeLibManager extends tools.haxelib.Main {
 		return infos;
 	}
 	
-	public function listLocalProjects(filter:String = null, loadRemote:Bool = false):Array<Dynamic> {
+	public function listLocalProjects(loadRemote:Bool = false):Array<Dynamic> {
 		var rep = getRepository();
 		var folders = FileSystem.readDirectory(rep);
-		if ( filter != null )
-			folders = folders.filter( function (f) return f.toLowerCase().indexOf(filter.toLowerCase()) > -1 );
 		var all = [];
 		for( p in folders ) {
 			if( p.charAt(0) != "." ) {

--- a/src/haxe/ui/haxelib/MainController.hx
+++ b/src/haxe/ui/haxelib/MainController.hx
@@ -22,10 +22,11 @@ import cpp.vm.Thread;
 @:build(haxe.ui.toolkit.core.Macros.buildController("assets/ui/main.xml"))
 class MainController extends XMLController {
 	private var _caller:AsyncThreadCaller;
+	private var _listData:Array<Dynamic>;
 	
 	public function new() {
 		refreshLocalRepository();
-		refreshRemoteInfo();
+		//refreshRemoteInfo();
 		
 		refreshLocal.onClick = function(e) {
 			refreshLocalRepository();
@@ -45,6 +46,10 @@ class MainController extends XMLController {
 			}
 		};
 		addMenuHandlers();
+		
+		filter.onChange = function(_) {
+			setProjectFilter(filter.text);
+		};
 		
 		/*
 		var t = Thread.create(testFunc);
@@ -94,6 +99,7 @@ class MainController extends XMLController {
 		localProjects.dataSource.allowEvents = false;
 		var projects:Array<Dynamic> = HaxeLibManager.instance.listLocalProjects();
 		var n:Int = 0;
+		_listData = [];
 		for (project in projects) {
 			var displayName:String = project.name + " [" + project.currentVersion + "]";
 			
@@ -108,6 +114,7 @@ class MainController extends XMLController {
 			};
 			
 			localProjects.dataSource.add(o);
+			_listData.push(o);
 			n++;
 			if (n > 1) {
 				//break;
@@ -153,6 +160,20 @@ class MainController extends XMLController {
 					UIManager.instance.showNotImplemented();
 			}
 		};
+	}
+	
+	private function setProjectFilter(filter:String):Void {
+		localProjects.dataSource.removeAll();
+		localProjects.dataSource.allowEvents = false;
+		
+		for (data in _listData) {
+			var projectName:String = cast data.project.name;
+			if (projectName.indexOf(filter) != -1) {
+				localProjects.dataSource.add(data);
+			}
+		}
+		
+		localProjects.dataSource.allowEvents = true;
 	}
 	
 	private function onProjectVersionChanged(e:VersionChangedEvent):Void {

--- a/src/haxe/ui/haxelib/MainController.hx
+++ b/src/haxe/ui/haxelib/MainController.hx
@@ -1,4 +1,6 @@
 package haxe.ui.haxelib;
+
+import haxe.Timer;
 import haxe.ui.haxelib.popups.ManageLocalProjectController;
 import haxe.ui.haxelib.popups.QueryUserController;
 import haxe.ui.haxelib.UIManager.InstallationCompleteEvent;
@@ -9,6 +11,7 @@ import haxe.ui.toolkit.core.PopupManager.PopupButton;
 import haxe.ui.toolkit.core.XMLController;
 import haxe.ui.toolkit.events.UIEvent;
 import haxe.ui.toolkit.util.pseudothreads.AsyncThreadCaller;
+import openfl.Lib;
 import tools.haxelib.Data.ProjectInfos;
 
 /*
@@ -23,10 +26,12 @@ import cpp.vm.Thread;
 class MainController extends XMLController {
 	private var _caller:AsyncThreadCaller;
 	private var _listData:Array<Dynamic>;
+	private var _lastFilterInput:Int;
+	private var _filterUpdateTreshold:Int = 75;
 	
 	public function new() {
 		refreshLocalRepository();
-		//refreshRemoteInfo();
+		refreshRemoteInfo();
 		
 		refreshLocal.onClick = function(e) {
 			refreshLocalRepository();
@@ -48,7 +53,15 @@ class MainController extends XMLController {
 		addMenuHandlers();
 		
 		filter.onChange = function(_) {
-			setProjectFilter(filter.text);
+			var currentTime = Lib.getTimer();
+			_lastFilterInput = currentTime;
+			
+			Timer.delay(function() {
+				// no new input since this timer was started?
+				if (_lastFilterInput == currentTime) {
+					setProjectFilter(filter.text);
+				}
+			}, _filterUpdateTreshold);
 		};
 		
 		/*


### PR DESCRIPTION
This adds a textbox that filters projects by their name, which is incredibly useful when a lot of projects are installed. I'd like this to be real-time, but it seems like it's not that performant, mainly because of `dataSource.removeAll()` it seems as `Timer.measure()` indicates? Not sure if I could be using better logic when it comes to updating the listview. This should probably run in a separate thread as well. For now I implemented a little hack with timers that prevents the filter update from running every time there's a new input.

I got rid of the filter functionality of `listLocalProjects()`. It worked fine, but it was too slow to be usable for this.

![](http://i.imgur.com/M2INfR7.png)

As you can see, the positioning isn't great yet either. Is there any simple way to ignore the textbox for the positioning of the next element(s)? There's no need to offset the listview in this case, it just adds whitespace.

Btw, what's the rationale behind disabling vsync and antialiasing in `<window />`? I got rid of that, and things seem to look better.
